### PR TITLE
Fallback to default GOPATH if env var is not set

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -124,7 +124,11 @@ func GetCachedBin(pkgRoot, binName, cmdPath string) (string, error) {
 	}
 
 	if _, err := os.Stat(cachedBin); os.IsNotExist(err) {
-		moduleBinSrcPath := path.Join(os.Getenv("GOPATH"), "pkg/mod", cmdPath)
+		goPath := os.Getenv("GOPATH")
+		if goPath == "" {
+			goPath = build.Default.GOPATH
+		}
+		moduleBinSrcPath := path.Join(goPath, "pkg", "mod", cmdPath)
 		if _, err := os.Stat(moduleBinSrcPath); os.IsNotExist(err) {
 			return "", fmt.Errorf("module %s not downloaded. Run `go mod download`", cmdPath)
 		}


### PR DESCRIPTION
If the user has not set their GOPATH environment variable we
incorrectly report that the desired sources has not been downloaded. We
therefore make sure to fallback to a default value.